### PR TITLE
Don't hash on Accept-Encoding; Varnish natively supports compression

### DIFF
--- a/production.vcl
+++ b/production.vcl
@@ -184,11 +184,6 @@ sub vcl_hash {
         hash_data(req.http.Authorization);
     }
 
-    # If the client supports compression, keep that in a different cache
-    if (req.http.Accept-Encoding) {
-        hash_data(req.http.Accept-Encoding);
-    }
-
     return (hash);
 }
 


### PR DESCRIPTION
Varnish 3 natively supports gzip. If a client supports gzip then the Accept-Encoding header is automatically normalized. Varnish will even request gzip'd content from the back-end even if a client doesn't support it and then decompress the content before sending it back to the client.

This allows Varnish to store a single compressed copy of the content for all clients, making the hash on Accept-Encoding unnecessary.

https://www.varnish-cache.org/docs/3.0/tutorial/compression.html

https://www.varnish-cache.org/docs/3.0/phk/gzip.html
