### PR TITLE
Session cookie logic for drupal.

### DIFF
--- a/conf.d/receive/drupal7.vcl
+++ b/conf.d/receive/drupal7.vcl
@@ -20,10 +20,16 @@ if (req.url ~ "install\.php|update\.php|cron\.php") {
 # Uncomment this to trigger the vcl_error() subroutine, which will HTML output you some variables (HTTP 700 = pretty debug)
 #error 700;
 
-# Anything else left?
-if (!req.http.cookie) {
-    unset req.http.cookie;
+# Do not cache users with session cookie, these may be:
+# * Authenticated users, never cache!
+# * Some modules generate session cookie even for anonymous users, for these modules to work
+#   caching must stop as long as there is a SESS* cookie
+if (req.http.Cookie ~ "SESS") {
+    return (pass);
 }
+
+# If no session cookie, all other cookies can go to the trash
+unset req.http.cookie;
 
 # Try a cache-lookup
 return (lookup);


### PR DESCRIPTION
There must be a logic for Drupal somewhere that stops caching when the user is authenticated or a session cookie has been generated for some reason.
