### PR TITLE
Fixes to error handling condition flow.

### DIFF
--- a/production.vcl
+++ b/production.vcl
@@ -278,9 +278,6 @@ sub vcl_error {
     } elsif (obj.status >= 400 && obj.status <= 499 ) {
         # use 404 error page for 4xx error
         include "conf.d/error-404.vcl";
-    } elsif (obj.status <= 200 && obj.status >= 299 ) {
-        # for other errors (not 5xx, not 4xx and not 2xx)
-        include "conf.d/error.vcl";
     } elseif (obj.status == 720) {
         # We use this special error status 720 to force redirects with 301 (permanent) redirects
         # To use this, call the following from anywhere in vcl_recv: error 720 "http://host/new.html"
@@ -294,6 +291,7 @@ sub vcl_error {
         set obj.http.Location = obj.response;
         return (deliver);
     } else {
+        # for other errors (not 5xx, not 4xx and not 2xx)
         include "conf.d/error.vcl";
     }
 


### PR DESCRIPTION
Error handling function has an issue.

The condition (obj.status <= 200 && obj.status >= 299) is always false.

Special cases should all be placed before the generic include for error.vcl.
